### PR TITLE
Fix compile error in util.pony. Enhance README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Pure Pony implementation of the ZeroMQ messaging library.
 ## Testing
 
 1. Get [stable](https://github.com/jemc/pony-stable) (to manage dependencies).
-2. Get [libsodium](https://download.libsodium.org/doc/installation/index.html) (required for [pony-sodium](https://github.com/jemc/pony-sodium)).
+2. Get
+   [libsodium](https://download.libsodium.org/doc/installation/index.html)
+   (required for [pony-sodium](https://github.com/jemc/pony-sodium)).
+   On OSX just to `brew install libsodium'.
+3. Fetch dependencies: `stable fetch`
 3. `stable env ponyc --debug zmq/test`
 4. `./test`

--- a/zmq/test/util.pony
+++ b/zmq/test/util.pony
@@ -62,12 +62,13 @@ actor _SocketReactor is zmq.SocketNotifiableActor
           (let peer, let message) = _messages.shift()
           (consume h)(peer, message)
         
-        | (var n: USize, let h: _MessageListLambdaPartial) =>
+        | (let n: USize, let h: _MessageListLambdaPartial) =>
           if _messages.size() < n then _handlers.unshift((n, consume h)); error end
           
           let list = List[zmq.Message]
-          while n > 0 do
-            n = n - 1
+          var n' = n
+          while n' > 0 do
+            n' = n' - 1
             (let peer, let message) = _messages.shift()
             list.push(message)
           end


### PR DESCRIPTION
- The ponyc compiler (no longer) allows 'var' in match statements.
  We now use a let and then copy the counter before iterating over it.
- Users need to do 'stable fetch' 

Context
- The util.pony bugfix is naive and might not be the right thing to do here.
- Currently can't test this bugfix because tests don't compile
